### PR TITLE
Added new parameter 'prefix' to the method dump()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ import cfg;
     ##
 
     Object env()
-    Method STRING .dump(BOOL stream=0)
+    Method STRING .dump(BOOL stream=0, STRING prefix="")
 
     Method BOOL .is_set(STRING name)
     Method STRING .get(STRING name, STRING fallback="")
@@ -49,7 +49,7 @@ import cfg;
         STRING name_delimiter=":",
         STRING value_delimiter=";")
     Method BOOL .reload()
-    Method STRING .dump(BOOL stream=0)
+    Method STRING .dump(BOOL stream=0, STRING prefix="")
 
     Method BOOL .is_set(STRING name)
     Method STRING .get(STRING name, STRING fallback="")

--- a/src/tests/file.dump.vtc
+++ b/src/tests/file.dump.vtc
@@ -7,6 +7,8 @@ server s1 {
 
 shell {
     cat > "${tmp}/test.ini" <<'EOF'
+var: what a hell?
+variable: hell
 field1:
 field2: ""
 field3: Hello "\o/"! á
@@ -32,7 +34,7 @@ varnish v1 -vcl+backend {
     }
 
     sub vcl_deliver {
-        set resp.http.result = file.dump();
+        set resp.http.result = file.dump(prefix=req.http.prefix);
     }
 
     sub vcl_synth {
@@ -45,13 +47,17 @@ varnish v1 -vcl+backend {
 client c1 {
     txreq
     rxresp
-    expect resp.http.result == {{"field1":"","field2":"\"\"","field3":"Hello \"\\o/\"! \u00c3\u00a1"}}
+    expect resp.http.result == {{"field1":"","field2":"\"\"","field3":"Hello \"\\o/\"! \u00c3\u00a1","var":"what a hell?","variable":"hell"}}
+
+    txreq -hdr "prefix: vari"
+    rxresp
+    expect resp.http.result == {{"variable":"hell"}}
 
     txreq -hdr "Synth: 1"
     rxresp
-    expect resp.body == {{"field1":"","field2":"\"\"","field3":"Hello \"\\o/\"! \u00c3\u00a1"}}
+    expect resp.body == {{"field1":"","field2":"\"\"","field3":"Hello \"\\o/\"! \u00c3\u00a1","var":"what a hell?","variable":"hell"}}
 } -run
 
-varnish v1 -expect client_req == 2
+varnish v1 -expect client_req == 3
 
 varnish v1 -expect MGT.child_panic == 0

--- a/src/variables.c
+++ b/src/variables.c
@@ -169,7 +169,7 @@ static const char *json_hex_chars = "0123456789abcdef";
     } while (0)
 
 const char *
-dump_variables(VRT_CTX, variables_t *variables, unsigned stream)
+dump_variables(VRT_CTX, variables_t *variables, unsigned stream, const char *prefix)
 {
     struct vsb *vsb = NULL;
     if (stream && (
@@ -189,6 +189,11 @@ dump_variables(VRT_CTX, variables_t *variables, unsigned stream)
     DUMP_CHAR('{');
     VRB_FOREACH(variable, variables, variables) {
         CHECK_OBJ_NOTNULL(variable, VARIABLE_MAGIC);
+        if (prefix != NULL &&
+            *prefix != '\0' &&
+            strncmp(variable->name, prefix, strlen(prefix)) != 0) {
+            continue;
+        }
         if (i > 0) {
             DUMP_CHAR(',');
         }

--- a/src/variables.h
+++ b/src/variables.h
@@ -24,6 +24,6 @@ void flush_variables(variables_t *variables);
 
 unsigned is_set_variable(VRT_CTX, variables_t *variables, const char *name);
 const char *get_variable(VRT_CTX, variables_t *variables, const char *name, const char *fallback);
-const char *dump_variables(VRT_CTX, variables_t *variables, unsigned stream);
+const char *dump_variables(VRT_CTX, variables_t *variables, unsigned stream, const char *prefix);
 
 #endif

--- a/src/vmod_cfg.vcc
+++ b/src/vmod_cfg.vcc
@@ -23,10 +23,13 @@ Description
     Beware environment variables are internally cached. This cache is populated
     when creating a new instance and it's never refreshed.
 
-$Method STRING .dump(BOOL stream=0)
+$Method STRING .dump(BOOL stream=0, STRING prefix="")
 
 Arguments
     stream: if enabled the JSON object will be streamed as a synthetic response.
+
+    prefix: if specified, the JSON object will only contains the variables that
+    start with that prefix.
 Description
     Returns a string representation of a JSON object containing all variables.
 
@@ -111,10 +114,13 @@ $Method BOOL .reload()
 Description
     Reloads contents of the file. A ``False`` value is returned on failure.
 
-$Method STRING .dump(BOOL stream=0)
+$Method STRING .dump(BOOL stream=0, STRING prefix="")
 
 Arguments
     stream: if enabled the JSON object will be streamed as a synthetic response.
+
+    prefix: if specified, the JSON object will only contains the variables that
+    start with that prefix.
 Description
     Returns a string representation of a JSON object containing all variables.
 

--- a/src/vmod_cfg_env.c
+++ b/src/vmod_cfg_env.c
@@ -74,9 +74,9 @@ vmod_env__fini(struct vmod_cfg_env **env)
 }
 
 VCL_STRING
-vmod_env_dump(VRT_CTX, struct vmod_cfg_env *env, VCL_BOOL stream)
+vmod_env_dump(VRT_CTX, struct vmod_cfg_env *env, VCL_BOOL stream, VCL_STRING prefix)
 {
-    return dump_variables(ctx, &env->variables, stream);
+    return dump_variables(ctx, &env->variables, stream, prefix);
 }
 
 VCL_BOOL

--- a/src/vmod_cfg_file.c
+++ b/src/vmod_cfg_file.c
@@ -406,11 +406,11 @@ vmod_file_reload(VRT_CTX, struct vmod_cfg_file *file)
 }
 
 VCL_STRING
-vmod_file_dump(VRT_CTX, struct vmod_cfg_file *file, VCL_BOOL stream)
+vmod_file_dump(VRT_CTX, struct vmod_cfg_file *file, VCL_BOOL stream, VCL_STRING prefix)
 {
     file_check(ctx, file, 0);
     AZ(pthread_rwlock_rdlock(&file->state.rwlock));
-    const char *result = dump_variables(ctx, file->state.variables, stream);
+    const char *result = dump_variables(ctx, file->state.variables, stream, prefix);
     AZ(pthread_rwlock_unlock(&file->state.rwlock));
     return result;
 }


### PR DESCRIPTION
Now is possible get the variables whose value start with the specified prefix.